### PR TITLE
Morph: implement task service

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,7 +1,9 @@
 import express from 'express';
 import { HealthController } from './controllers/health.controller';
+import { TaskController } from './controllers/task.controller';
 import { IdentityProvider } from './middleware/identity.provider';
 import { PermissionServiceClient } from './clients/permission-service.client';
+import { TaskService } from './services/task.service';
 
 export function createApp(permissionServiceConfig: { host: string; port: number }) {
   const app = express();
@@ -9,10 +11,14 @@ export function createApp(permissionServiceConfig: { host: string; port: number 
 
   const identityProvider = new IdentityProvider();
   const permissionServiceClient = new PermissionServiceClient(permissionServiceConfig);
+  const taskService = new TaskService(permissionServiceClient);
 
   const healthController = new HealthController();
+  const taskController = new TaskController(taskService, identityProvider);
 
   app.get('/health', (req, res) => healthController.getHealth(req, res));
+  app.post('/tasks', (req, res) => taskController.createTask(req, res));
+  app.get('/tasks', (req, res) => taskController.getTasks(req, res));
 
   return app;
 }

--- a/src/controllers/health.controller.ts
+++ b/src/controllers/health.controller.ts
@@ -1,10 +1,7 @@
 import { Request, Response } from 'express';
 
 export class HealthController {
-  constructor() {}
-
-  async getHealth(req: Request, res: Response): Promise<void> {
-    res.status(200).json({ status: 'OK' });
-    return;
+  getHealth(req: Request, res: Response): void {
+    res.status(200).json({ status: "OK" });
   }
 }

--- a/src/controllers/task.controller.ts
+++ b/src/controllers/task.controller.ts
@@ -1,0 +1,48 @@
+import { Request, Response } from 'express';
+import { TaskService } from '../services/task.service';
+import { IdentityProvider } from '../middleware/identity.provider';
+
+export class TaskController {
+  constructor(
+    private taskService: TaskService,
+    private identityProvider: IdentityProvider
+  ) {}
+
+  async createTask(req: Request, res: Response): Promise<void> {
+    try {
+      const userId = this.identityProvider.getUserId(req);
+      if (!userId) {
+        res.status(401).json({ error: 'User ID not provided' });
+        return;
+      }
+
+      const task = await this.taskService.createTask(userId, req.body);
+      res.status(201).json(task);
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('Insufficient permissions')) {
+        res.status(403).json({ error: error.message });
+      } else {
+        res.status(500).json({ error: 'Internal server error' });
+      }
+    }
+  }
+
+  async getTasks(req: Request, res: Response): Promise<void> {
+    try {
+      const userId = this.identityProvider.getUserId(req);
+      if (!userId) {
+        res.status(401).json({ error: 'User ID not provided' });
+        return;
+      }
+
+      const tasks = await this.taskService.getTasks(userId);
+      res.status(200).json(tasks);
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('Insufficient permissions')) {
+        res.status(403).json({ error: error.message });
+      } else {
+        res.status(500).json({ error: 'Internal server error' });
+      }
+    }
+  }
+}

--- a/src/models/task.model.ts
+++ b/src/models/task.model.ts
@@ -1,0 +1,13 @@
+export interface Task {
+  id: string;
+  projectId: string;
+  name: string;
+  description: string;
+  userId: string;
+}
+
+export interface CreateTaskRequest {
+  projectId: string;
+  name: string;
+  description: string;
+}

--- a/src/services/task.service.ts
+++ b/src/services/task.service.ts
@@ -1,0 +1,34 @@
+import { v4 as uuidv4 } from 'uuid';
+import { Task, CreateTaskRequest } from '../models/task.model';
+import { PermissionServiceClient, Domain, Action } from '../clients/permission-service.client';
+
+export class TaskService {
+  private tasks: Task[] = [];
+
+  constructor(private permissionServiceClient: PermissionServiceClient) {}
+
+  async createTask(userId: string, createTaskRequest: CreateTaskRequest): Promise<Task> {
+    const hasPermission = await this.permissionServiceClient.hasPermission(userId, Domain.TASK, Action.CREATE);
+    if (!hasPermission) {
+      throw new Error('Insufficient permissions to create task');
+    }
+
+    const task: Task = {
+      id: uuidv4(),
+      userId,
+      ...createTaskRequest
+    };
+
+    this.tasks.push(task);
+    return task;
+  }
+
+  async getTasks(userId: string): Promise<Task[]> {
+    const hasPermission = await this.permissionServiceClient.hasPermission(userId, Domain.TASK, Action.LIST);
+    if (!hasPermission) {
+      throw new Error('Insufficient permissions to list tasks');
+    }
+
+    return this.tasks.filter(task => task.userId === userId);
+  }
+}

--- a/tests/integration/task.test.ts
+++ b/tests/integration/task.test.ts
@@ -1,0 +1,191 @@
+import request from 'supertest';
+import express from 'express';
+import nock from 'nock';
+import { createApp } from '../../src/app';
+
+const permissionServiceHost = 'localhost';
+const permissionServicePort = 3001;
+const permissionServiceBaseUrl = `http://${permissionServiceHost}:${permissionServicePort}`;
+
+describe('Task Integration Tests', () => {
+  let app: express.Application;
+
+  beforeAll(() => {
+    app = createApp({ host: permissionServiceHost, port: permissionServicePort });
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  describe('POST /tasks', () => {
+    it('should create a task when user has permission', async () => {
+      const userId = 'user-123';
+      const taskData = {
+        projectId: 'project-456',
+        name: 'Test Task',
+        description: 'Test task description'
+      };
+
+      // Mock permission service to allow CREATE
+      nock(permissionServiceBaseUrl)
+        .get('/permissions/check')
+        .query({
+          subjectId: userId,
+          domain: 'TASK',
+          action: 'CREATE'
+        })
+        .reply(200, { allowed: true });
+
+      const response = await request(app)
+        .post('/tasks')
+        .set('identity-user-id', userId)
+        .send(taskData);
+
+      expect(response.status).toBe(201);
+      expect(response.body).toMatchObject({
+        projectId: taskData.projectId,
+        name: taskData.name,
+        description: taskData.description,
+        userId: userId
+      });
+      expect(response.body.id).toBeDefined();
+    });
+
+    it('should return 401 when user ID is not provided', async () => {
+      const taskData = {
+        projectId: 'project-456',
+        name: 'Test Task',
+        description: 'Test task description'
+      };
+
+      const response = await request(app)
+        .post('/tasks')
+        .send(taskData);
+
+      expect(response.status).toBe(401);
+      expect(response.body).toEqual({ error: 'User ID not provided' });
+    });
+
+    it('should return 403 when user does not have permission', async () => {
+      const userId = 'user-123';
+      const taskData = {
+        projectId: 'project-456',
+        name: 'Test Task',
+        description: 'Test task description'
+      };
+
+      // Mock permission service to deny CREATE
+      nock(permissionServiceBaseUrl)
+        .get('/permissions/check')
+        .query({
+          subjectId: userId,
+          domain: 'TASK',
+          action: 'CREATE'
+        })
+        .reply(200, { allowed: false });
+
+      const response = await request(app)
+        .post('/tasks')
+        .set('identity-user-id', userId)
+        .send(taskData);
+
+      expect(response.status).toBe(403);
+      expect(response.body.error).toContain('Insufficient permissions');
+    });
+  });
+
+  describe('GET /tasks', () => {
+    it('should get tasks when user has permission', async () => {
+      const userId = 'user-123';
+
+      // Mock permission service to allow LIST
+      nock(permissionServiceBaseUrl)
+        .get('/permissions/check')
+        .query({
+          subjectId: userId,
+          domain: 'TASK',
+          action: 'LIST'
+        })
+        .reply(200, { allowed: true });
+
+      const response = await request(app)
+        .get('/tasks')
+        .set('identity-user-id', userId);
+
+      expect(response.status).toBe(200);
+      expect(Array.isArray(response.body)).toBe(true);
+    });
+
+    it('should return 401 when user ID is not provided', async () => {
+      const response = await request(app)
+        .get('/tasks');
+
+      expect(response.status).toBe(401);
+      expect(response.body).toEqual({ error: 'User ID not provided' });
+    });
+
+    it('should return 403 when user does not have permission', async () => {
+      const userId = 'user-123';
+
+      // Mock permission service to deny LIST
+      nock(permissionServiceBaseUrl)
+        .get('/permissions/check')
+        .query({
+          subjectId: userId,
+          domain: 'TASK',
+          action: 'LIST'
+        })
+        .reply(200, { allowed: false });
+
+      const response = await request(app)
+        .get('/tasks')
+        .set('identity-user-id', userId);
+
+      expect(response.status).toBe(403);
+      expect(response.body.error).toContain('Insufficient permissions');
+    });
+
+    it('should return only tasks created by the user', async () => {
+      const userId1 = 'user-123';
+      const userId2 = 'user-456';
+      const taskData = {
+        projectId: 'project-789',
+        name: 'User Task',
+        description: 'Task for specific user'
+      };
+
+      // Create task for user1
+      nock(permissionServiceBaseUrl)
+        .get('/permissions/check')
+        .query({
+          subjectId: userId1,
+          domain: 'TASK',
+          action: 'CREATE'
+        })
+        .reply(200, { allowed: true });
+
+      await request(app)
+        .post('/tasks')
+        .set('identity-user-id', userId1)
+        .send(taskData);
+
+      // Get tasks for user2 (should be empty)
+      nock(permissionServiceBaseUrl)
+        .get('/permissions/check')
+        .query({
+          subjectId: userId2,
+          domain: 'TASK',
+          action: 'LIST'
+        })
+        .reply(200, { allowed: true });
+
+      const response = await request(app)
+        .get('/tasks')
+        .set('identity-user-id', userId2);
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
This PR contains the following modifications:

- AI (anthropic/claude-sonnet-4-20250514):
```
implement task controller and task service.
It should contain two features:
- user can create tasks with project id, name and description
- user can get tasks
Store data in memory in the task service.

user id is passed as a header and should be retrieved by identity provider in the controller and passed into the service. Then the service needs to use that user id to check permission service whether user has access (tests should assume the user has access). Permissions are CREATE and LIST in Task domain

Make integration tests for those two features. It should mock permission service using nock, so the test is a black box integration test.


```
 (Single file: No)

Generated by Morph.