### PR TITLE
Morph: Permission migration

### DIFF
--- a/src/clients/permission-service.client.ts
+++ b/src/clients/permission-service.client.ts
@@ -33,17 +33,25 @@ export class PermissionServiceClient {
     console.log(`[PermissionServiceClient] Initialized with baseUrl: ${this.baseUrl}`);
   }
 
-  async hasPermission(subjectId: string, domain: Domain, action: Action): Promise<boolean> {
-    console.log(`[PermissionServiceClient] Checking permission for subjectId=${subjectId}, domain=${domain}, action=${action}`);
+  async hasPermission(subjectId: string, domain: Domain, action: Action, tenantId?: string): Promise<boolean> {
+    console.log(`[PermissionServiceClient] Checking permission for subjectId=${subjectId}, domain=${domain}, action=${action}, tenantId=${tenantId}`);
     try {
+      const params: any = {
+        subjectId,
+        domain,
+        action
+      };
+      
+      if (tenantId) {
+        params.tenantId = tenantId;
+      }
+
+      const endpoint = tenantId ? '/permissions/v2/check' : '/permissions/check';
+      
       const response = await axios.get<PermissionResponse>(
-        `${this.baseUrl}/permissions/check`,
+        `${this.baseUrl}${endpoint}`,
         {
-          params: {
-            subjectId,
-            domain,
-            action
-          }
+          params
         }
       );
       console.log(`[PermissionServiceClient] Permission check response: allowed=${response.data.allowed}`);

--- a/src/middleware/identity.provider.ts
+++ b/src/middleware/identity.provider.ts
@@ -6,4 +6,10 @@ export class IdentityProvider {
     console.log(`[IdentityProvider] Extracted userId:`, userId);
     return userId || null;
   }
+
+  getTenantId(req: Request): string | null {
+    const tenantId = req.header('identity-tenant-id');
+    console.log(`[IdentityProvider] Extracted tenantId:`, tenantId);
+    return tenantId || null;
+  }
 }

--- a/src/services/task.service.ts
+++ b/src/services/task.service.ts
@@ -7,9 +7,9 @@ export class TaskService {
 
   constructor(private permissionServiceClient: PermissionServiceClient) {}
 
-  async createTask(userId: string, createTaskRequest: CreateTaskRequest): Promise<Task> {
-    console.log(`[TaskService] Checking CREATE permission for user: ${userId}`);
-    const hasPermission = await this.permissionServiceClient.hasPermission(userId, Domain.TASK, Action.CREATE);
+  async createTask(userId: string, createTaskRequest: CreateTaskRequest, tenantId?: string): Promise<Task> {
+    console.log(`[TaskService] Checking CREATE permission for user: ${userId}, tenant: ${tenantId}`);
+    const hasPermission = await this.permissionServiceClient.hasPermission(userId, Domain.TASK, Action.CREATE, tenantId);
     if (!hasPermission) {
       console.warn(`[TaskService] User ${userId} lacks permission to create task`);
       throw new Error('Insufficient permissions to create task');
@@ -26,9 +26,9 @@ export class TaskService {
     return task;
   }
 
-  async getTasks(userId: string): Promise<Task[]> {
-    console.log(`[TaskService] Checking LIST permission for user: ${userId}`);
-    const hasPermission = await this.permissionServiceClient.hasPermission(userId, Domain.TASK, Action.LIST);
+  async getTasks(userId: string, tenantId?: string): Promise<Task[]> {
+    console.log(`[TaskService] Checking LIST permission for user: ${userId}, tenant: ${tenantId}`);
+    const hasPermission = await this.permissionServiceClient.hasPermission(userId, Domain.TASK, Action.LIST, tenantId);
     if (!hasPermission) {
       console.warn(`[TaskService] User ${userId} lacks permission to list tasks`);
       throw new Error('Insufficient permissions to list tasks');


### PR DESCRIPTION
This PR contains the following modifications:

- AI (anthropic/claude-sonnet-4-20250514):
```
The company is moving to multi-tenant setup. This means we need to re-work how we evaluate permissions. Infra team has already implemented authentication and they add new identity-tenant-id header in the api-gateway.

The owners of permission-service have already implemented a new endpoint /v2/check that can accept tenantId along with existing subjectId.

So now all the other components need to be updated to the new version of permission-service. But all the feature teams are busy with building a new shiny AI integration and can not prioritize this upgrade.

The only hope is you.
```
 (Single file: No)

Generated by Morph.