### PR TITLE
Morph: Permission migration

### DIFF
--- a/src/clients/permission-service.client.ts
+++ b/src/clients/permission-service.client.ts
@@ -33,14 +33,15 @@ export class PermissionServiceClient {
     console.log(`[PermissionServiceClient] Initialized with baseUrl: ${this.baseUrl}`);
   }
 
-  async hasPermission(subjectId: string, domain: Domain, action: Action): Promise<boolean> {
-    console.log(`[PermissionServiceClient] Checking permission for subjectId=${subjectId}, domain=${domain}, action=${action}`);
+  async hasPermission(subjectId: string, tenantId: string, domain: Domain, action: Action): Promise<boolean> {
+    console.log(`[PermissionServiceClient] Checking permission for subjectId=${subjectId}, tenantId=${tenantId}, domain=${domain}, action=${action}`);
     try {
       const response = await axios.get<PermissionResponse>(
-        `${this.baseUrl}/permissions/check`,
+        `${this.baseUrl}/permissions/v2/check`,
         {
           params: {
             subjectId,
+            tenantId,
             domain,
             action
           }

--- a/src/controllers/task.controller.ts
+++ b/src/controllers/task.controller.ts
@@ -12,13 +12,19 @@ export class TaskController {
     try {
       console.log('createTask called with body:', req.body);
       const userId = this.identityProvider.getUserId(req);
+      const tenantId = this.identityProvider.getTenantId(req);
       if (!userId) {
         console.warn('User ID not provided for createTask');
         res.status(401).json({ error: 'User ID not provided' });
         return;
       }
+      if (!tenantId) {
+        console.warn('Tenant ID not provided for createTask');
+        res.status(401).json({ error: 'Tenant ID not provided' });
+        return;
+      }
 
-      const task = await this.taskService.createTask(userId, req.body);
+      const task = await this.taskService.createTask(userId, tenantId, req.body);
       console.log('Task created:', task);
       res.status(201).json(task);
     } catch (error) {
@@ -35,14 +41,20 @@ export class TaskController {
     try {
       console.log('getTasks called');
       const userId = this.identityProvider.getUserId(req);
+      const tenantId = this.identityProvider.getTenantId(req);
       if (!userId) {
         console.warn('User ID not provided for getTasks');
         res.status(401).json({ error: 'User ID not provided' });
         return;
       }
+      if (!tenantId) {
+        console.warn('Tenant ID not provided for getTasks');
+        res.status(401).json({ error: 'Tenant ID not provided' });
+        return;
+      }
 
-      const tasks = await this.taskService.getTasks(userId);
-      console.log(`Tasks retrieved for user ${userId}:`, tasks);
+      const tasks = await this.taskService.getTasks(userId, tenantId);
+      console.log(`Tasks retrieved for user ${userId} tenant ${tenantId}:`, tasks);
       res.status(200).json(tasks);
     } catch (error) {
       console.error('Error occurred in getTasks:', error);

--- a/src/middleware/identity.provider.ts
+++ b/src/middleware/identity.provider.ts
@@ -6,4 +6,10 @@ export class IdentityProvider {
     console.log(`[IdentityProvider] Extracted userId:`, userId);
     return userId || null;
   }
+
+  getTenantId(req: Request): string | null {
+    const tenantId = req.header('identity-tenant-id');
+    console.log(`[IdentityProvider] Extracted tenantId:`, tenantId);
+    return tenantId || null;
+  }
 }

--- a/src/services/task.service.ts
+++ b/src/services/task.service.ts
@@ -7,11 +7,11 @@ export class TaskService {
 
   constructor(private permissionServiceClient: PermissionServiceClient) {}
 
-  async createTask(userId: string, createTaskRequest: CreateTaskRequest): Promise<Task> {
-    console.log(`[TaskService] Checking CREATE permission for user: ${userId}`);
-    const hasPermission = await this.permissionServiceClient.hasPermission(userId, Domain.TASK, Action.CREATE);
+  async createTask(userId: string, tenantId: string, createTaskRequest: CreateTaskRequest): Promise<Task> {
+    console.log(`[TaskService] Checking CREATE permission for user: ${userId}, tenant: ${tenantId}`);
+    const hasPermission = await this.permissionServiceClient.hasPermission(userId, tenantId, Domain.TASK, Action.CREATE);
     if (!hasPermission) {
-      console.warn(`[TaskService] User ${userId} lacks permission to create task`);
+      console.warn(`[TaskService] User ${userId} (tenant: ${tenantId}) lacks permission to create task`);
       throw new Error('Insufficient permissions to create task');
     }
 
@@ -22,20 +22,20 @@ export class TaskService {
     };
 
     this.tasks.push(task);
-    console.log(`[TaskService] Created task with id: ${task.id} for user: ${userId}`);
+    console.log(`[TaskService] Created task with id: ${task.id} for user: ${userId} tenant: ${tenantId}`);
     return task;
   }
 
-  async getTasks(userId: string): Promise<Task[]> {
-    console.log(`[TaskService] Checking LIST permission for user: ${userId}`);
-    const hasPermission = await this.permissionServiceClient.hasPermission(userId, Domain.TASK, Action.LIST);
+  async getTasks(userId: string, tenantId: string): Promise<Task[]> {
+    console.log(`[TaskService] Checking LIST permission for user: ${userId}, tenant: ${tenantId}`);
+    const hasPermission = await this.permissionServiceClient.hasPermission(userId, tenantId, Domain.TASK, Action.LIST);
     if (!hasPermission) {
-      console.warn(`[TaskService] User ${userId} lacks permission to list tasks`);
+      console.warn(`[TaskService] User ${userId} (tenant: ${tenantId}) lacks permission to list tasks`);
       throw new Error('Insufficient permissions to list tasks');
     }
 
     const userTasks = this.tasks.filter(task => task.userId === userId);
-    console.log(`[TaskService] Found ${userTasks.length} tasks for user: ${userId}`);
+    console.log(`[TaskService] Found ${userTasks.length} tasks for user: ${userId} tenant: ${tenantId}`);
     return userTasks;
   }
 }


### PR DESCRIPTION
This PR contains the following modifications:

- AI (anthropic/claude-sonnet-4-20250514):
```
The company is moving to multi-tenant setup. This means we need to re-work how we evaluate permissions. Infra team has already implemented authentication and they add new identity-tenant-id header in the api-gateway.

The owners of permission-service have already implemented a new endpoint /v2/check that can accept tenantId along with existing subjectId.

So now all the other components need to be updated to the new version of permission-service. But all the feature teams are busy with building a new shiny AI integration and can not prioritize this upgrade.

The only hope is you.
```
 (Single file: No)

Generated by Morph.