### PR TITLE
Morph: migrate to permission service

### DIFF
--- a/src/clients/permission-service.client.ts
+++ b/src/clients/permission-service.client.ts
@@ -33,14 +33,15 @@ export class PermissionServiceClient {
     console.log(`[PermissionServiceClient] Initialized with baseUrl: ${this.baseUrl}`);
   }
 
-  async hasPermission(subjectId: string, domain: Domain, action: Action): Promise<boolean> {
-    console.log(`[PermissionServiceClient] Checking permission for subjectId=${subjectId}, domain=${domain}, action=${action}`);
+  async hasPermission(subjectId: string, tenantId: string, domain: Domain, action: Action): Promise<boolean> {
+    console.log(`[PermissionServiceClient] Checking permission for subjectId=${subjectId}, tenantId=${tenantId}, domain=${domain}, action=${action}`);
     try {
       const response = await axios.get<PermissionResponse>(
-        `${this.baseUrl}/permissions/check`,
+        `${this.baseUrl}/permissions/v2/check`,
         {
           params: {
             subjectId,
+            tenantId,
             domain,
             action
           }
@@ -50,12 +51,11 @@ export class PermissionServiceClient {
       return response.data.allowed;
     } catch (error) {
       if (axios.isAxiosError(error)) {
-        // Handle specific error cases if needed
         console.error(`[PermissionServiceClient] Permission check failed: ${error.message}`);
       } else {
         console.error(`[PermissionServiceClient] Unexpected error during permission check: ${error}`);
       }
-      return false; // Default to denying permission on error
+      return false;
     }
   }
 }

--- a/src/controllers/task.controller.ts
+++ b/src/controllers/task.controller.ts
@@ -12,13 +12,15 @@ export class TaskController {
     try {
       console.log('createTask called with body:', req.body);
       const userId = this.identityProvider.getUserId(req);
-      if (!userId) {
-        console.warn('User ID not provided for createTask');
-        res.status(401).json({ error: 'User ID not provided' });
+      const tenantId = this.identityProvider.getTenantId(req);
+
+      if (!userId || !tenantId) {
+        console.warn('User ID or Tenant ID not provided for createTask');
+        res.status(401).json({ error: 'User ID or Tenant ID not provided' });
         return;
       }
 
-      const task = await this.taskService.createTask(userId, req.body);
+      const task = await this.taskService.createTask(userId, tenantId, req.body);
       console.log('Task created:', task);
       res.status(201).json(task);
     } catch (error) {
@@ -35,14 +37,16 @@ export class TaskController {
     try {
       console.log('getTasks called');
       const userId = this.identityProvider.getUserId(req);
-      if (!userId) {
-        console.warn('User ID not provided for getTasks');
-        res.status(401).json({ error: 'User ID not provided' });
+      const tenantId = this.identityProvider.getTenantId(req);
+
+      if (!userId || !tenantId) {
+        console.warn('User ID or Tenant ID not provided for getTasks');
+        res.status(401).json({ error: 'User ID or Tenant ID not provided' });
         return;
       }
 
-      const tasks = await this.taskService.getTasks(userId);
-      console.log(`Tasks retrieved for user ${userId}:`, tasks);
+      const tasks = await this.taskService.getTasks(userId, tenantId);
+      console.log(`Tasks retrieved for user ${userId} in tenant ${tenantId}:`, tasks);
       res.status(200).json(tasks);
     } catch (error) {
       console.error('Error occurred in getTasks:', error);

--- a/src/middleware/identity.provider.ts
+++ b/src/middleware/identity.provider.ts
@@ -6,4 +6,10 @@ export class IdentityProvider {
     console.log(`[IdentityProvider] Extracted userId:`, userId);
     return userId || null;
   }
+
+  getTenantId(req: Request): string | null {
+    const tenantId = req.header('identity-tenant-id');
+    console.log(`[IdentityProvider] Extracted tenantId:`, tenantId);
+    return tenantId || null;
+  }
 }

--- a/src/services/task.service.ts
+++ b/src/services/task.service.ts
@@ -7,35 +7,36 @@ export class TaskService {
 
   constructor(private permissionServiceClient: PermissionServiceClient) {}
 
-  async createTask(userId: string, createTaskRequest: CreateTaskRequest): Promise<Task> {
-    console.log(`[TaskService] Checking CREATE permission for user: ${userId}`);
-    const hasPermission = await this.permissionServiceClient.hasPermission(userId, Domain.TASK, Action.CREATE);
+  async createTask(userId: string, tenantId: string, createTaskRequest: CreateTaskRequest): Promise<Task> {
+    console.log(`[TaskService] Checking CREATE permission for user: ${userId}, tenant: ${tenantId}`);
+    const hasPermission = await this.permissionServiceClient.hasPermission(userId, tenantId, Domain.TASK, Action.CREATE);
     if (!hasPermission) {
-      console.warn(`[TaskService] User ${userId} lacks permission to create task`);
+      console.warn(`[TaskService] User ${userId} in tenant ${tenantId} lacks permission to create task`);
       throw new Error('Insufficient permissions to create task');
     }
 
     const task: Task = {
       id: uuidv4(),
       userId,
+      tenantId,
       ...createTaskRequest
     };
 
     this.tasks.push(task);
-    console.log(`[TaskService] Created task with id: ${task.id} for user: ${userId}`);
+    console.log(`[TaskService] Created task with id: ${task.id} for user: ${userId} in tenant: ${tenantId}`);
     return task;
   }
 
-  async getTasks(userId: string): Promise<Task[]> {
-    console.log(`[TaskService] Checking LIST permission for user: ${userId}`);
-    const hasPermission = await this.permissionServiceClient.hasPermission(userId, Domain.TASK, Action.LIST);
+  async getTasks(userId: string, tenantId: string): Promise<Task[]> {
+    console.log(`[TaskService] Checking LIST permission for user: ${userId}, tenant: ${tenantId}`);
+    const hasPermission = await this.permissionServiceClient.hasPermission(userId, tenantId, Domain.TASK, Action.LIST);
     if (!hasPermission) {
-      console.warn(`[TaskService] User ${userId} lacks permission to list tasks`);
+      console.warn(`[TaskService] User ${userId} in tenant ${tenantId} lacks permission to list tasks`);
       throw new Error('Insufficient permissions to list tasks');
     }
 
-    const userTasks = this.tasks.filter(task => task.userId === userId);
-    console.log(`[TaskService] Found ${userTasks.length} tasks for user: ${userId}`);
+    const userTasks = this.tasks.filter(task => task.userId === userId && task.tenantId === tenantId);
+    console.log(`[TaskService] Found ${userTasks.length} tasks for user: ${userId} in tenant: ${tenantId}`);
     return userTasks;
   }
 }

--- a/tests/integration/health.test.ts
+++ b/tests/integration/health.test.ts
@@ -4,7 +4,6 @@ import { createApp } from '../../src/app';
 
 const permissionServiceHost = 'localhost';
 const permissionServicePort = 3001;
-const permissionServiceBaseUrl = `http://${permissionServiceHost}:${permissionServicePort}`;
 
 describe('Health Integration Tests', () => {
   let app: express.Application;

--- a/tests/integration/task.test.ts
+++ b/tests/integration/task.test.ts
@@ -21,6 +21,7 @@ describe('Task Integration Tests', () => {
   describe('POST /tasks', () => {
     it('should create a task when user has permission', async () => {
       const userId = 'user-123';
+      const tenantId = 'tenant-abc';
       const taskData = {
         projectId: 'project-456',
         name: 'Test Task',
@@ -29,9 +30,10 @@ describe('Task Integration Tests', () => {
 
       // Mock permission service to allow CREATE
       nock(permissionServiceBaseUrl)
-        .get('/permissions/check')
+        .get('/permissions/v2/check')
         .query({
           subjectId: userId,
+          tenantId: tenantId,
           domain: 'TASK',
           action: 'CREATE'
         })
@@ -40,6 +42,7 @@ describe('Task Integration Tests', () => {
       const response = await request(app)
         .post('/tasks')
         .set('identity-user-id', userId)
+        .set('identity-tenant-id', tenantId)
         .send(taskData);
 
       expect(response.status).toBe(201);
@@ -47,12 +50,13 @@ describe('Task Integration Tests', () => {
         projectId: taskData.projectId,
         name: taskData.name,
         description: taskData.description,
-        userId: userId
+        userId: userId,
+        tenantId: tenantId
       });
       expect(response.body.id).toBeDefined();
     });
 
-    it('should return 401 when user ID is not provided', async () => {
+    it('should return 401 when user ID or tenant ID is not provided', async () => {
       const taskData = {
         projectId: 'project-456',
         name: 'Test Task',
@@ -61,14 +65,24 @@ describe('Task Integration Tests', () => {
 
       const response = await request(app)
         .post('/tasks')
+        .set('identity-user-id', 'user-123')
         .send(taskData);
 
       expect(response.status).toBe(401);
-      expect(response.body).toEqual({ error: 'User ID not provided' });
+      expect(response.body).toEqual({ error: 'User ID or Tenant ID not provided' });
+
+      const response2 = await request(app)
+        .post('/tasks')
+        .set('identity-tenant-id', 'tenant-abc')
+        .send(taskData);
+
+      expect(response2.status).toBe(401);
+      expect(response2.body).toEqual({ error: 'User ID or Tenant ID not provided' });
     });
 
     it('should return 403 when user does not have permission', async () => {
       const userId = 'user-123';
+      const tenantId = 'tenant-abc';
       const taskData = {
         projectId: 'project-456',
         name: 'Test Task',
@@ -77,9 +91,10 @@ describe('Task Integration Tests', () => {
 
       // Mock permission service to deny CREATE
       nock(permissionServiceBaseUrl)
-        .get('/permissions/check')
+        .get('/permissions/v2/check')
         .query({
           subjectId: userId,
+          tenantId: tenantId,
           domain: 'TASK',
           action: 'CREATE'
         })
@@ -88,6 +103,7 @@ describe('Task Integration Tests', () => {
       const response = await request(app)
         .post('/tasks')
         .set('identity-user-id', userId)
+        .set('identity-tenant-id', tenantId)
         .send(taskData);
 
       expect(response.status).toBe(403);
@@ -98,12 +114,14 @@ describe('Task Integration Tests', () => {
   describe('GET /tasks', () => {
     it('should get tasks when user has permission', async () => {
       const userId = 'user-123';
+      const tenantId = 'tenant-abc';
 
       // Mock permission service to allow LIST
       nock(permissionServiceBaseUrl)
-        .get('/permissions/check')
+        .get('/permissions/v2/check')
         .query({
           subjectId: userId,
+          tenantId: tenantId,
           domain: 'TASK',
           action: 'LIST'
         })
@@ -111,28 +129,31 @@ describe('Task Integration Tests', () => {
 
       const response = await request(app)
         .get('/tasks')
-        .set('identity-user-id', userId);
+        .set('identity-user-id', userId)
+        .set('identity-tenant-id', tenantId);
 
       expect(response.status).toBe(200);
       expect(Array.isArray(response.body)).toBe(true);
     });
 
-    it('should return 401 when user ID is not provided', async () => {
+    it('should return 401 when user ID or tenant ID is not provided', async () => {
       const response = await request(app)
         .get('/tasks');
 
       expect(response.status).toBe(401);
-      expect(response.body).toEqual({ error: 'User ID not provided' });
+      expect(response.body).toEqual({ error: 'User ID or Tenant ID not provided' });
     });
 
     it('should return 403 when user does not have permission', async () => {
       const userId = 'user-123';
+      const tenantId = 'tenant-abc';
 
       // Mock permission service to deny LIST
       nock(permissionServiceBaseUrl)
-        .get('/permissions/check')
+        .get('/permissions/v2/check')
         .query({
           subjectId: userId,
+          tenantId: tenantId,
           domain: 'TASK',
           action: 'LIST'
         })
@@ -140,26 +161,37 @@ describe('Task Integration Tests', () => {
 
       const response = await request(app)
         .get('/tasks')
-        .set('identity-user-id', userId);
+        .set('identity-user-id', userId)
+        .set('identity-tenant-id', tenantId);
 
       expect(response.status).toBe(403);
       expect(response.body.error).toContain('Insufficient permissions');
     });
 
-    it('should return only tasks created by the user', async () => {
+    it('should return only tasks created by the user in the same tenant', async () => {
       const userId1 = 'user-123';
+      const tenantId1 = 'tenant-abc';
       const userId2 = 'user-456';
-      const taskData = {
+      const tenantId2 = 'tenant-xyz';
+
+      const taskData1 = {
         projectId: 'project-789',
-        name: 'User Task',
-        description: 'Task for specific user'
+        name: 'User Task 1',
+        description: 'Task for specific user in tenant 1'
       };
 
-      // Create task for user1
+      const taskData2 = {
+        projectId: 'project-101',
+        name: 'User Task 2',
+        description: 'Task for specific user in tenant 2'
+      };
+
+      // Create task for user1 in tenant1
       nock(permissionServiceBaseUrl)
-        .get('/permissions/check')
+        .get('/permissions/v2/check')
         .query({
           subjectId: userId1,
+          tenantId: tenantId1,
           domain: 'TASK',
           action: 'CREATE'
         })
@@ -168,24 +200,69 @@ describe('Task Integration Tests', () => {
       await request(app)
         .post('/tasks')
         .set('identity-user-id', userId1)
-        .send(taskData);
+        .set('identity-tenant-id', tenantId1)
+        .send(taskData1);
 
-      // Get tasks for user2 (should be empty)
+      // Create task for user2 in tenant2
       nock(permissionServiceBaseUrl)
-        .get('/permissions/check')
+        .get('/permissions/v2/check')
         .query({
           subjectId: userId2,
+          tenantId: tenantId2,
+          domain: 'TASK',
+          action: 'CREATE'
+        })
+        .reply(200, { allowed: true });
+
+      await request(app)
+        .post('/tasks')
+        .set('identity-user-id', userId2)
+        .set('identity-tenant-id', tenantId2)
+        .send(taskData2);
+
+
+      // Get tasks for user1 in tenant1 (should return task1)
+      nock(permissionServiceBaseUrl)
+        .get('/permissions/v2/check')
+        .query({
+          subjectId: userId1,
+          tenantId: tenantId1,
           domain: 'TASK',
           action: 'LIST'
         })
         .reply(200, { allowed: true });
 
-      const response = await request(app)
+      const response1 = await request(app)
         .get('/tasks')
-        .set('identity-user-id', userId2);
+        .set('identity-user-id', userId1)
+        .set('identity-tenant-id', tenantId1);
 
-      expect(response.status).toBe(200);
-      expect(response.body).toEqual([]);
+      expect(response1.status).toBe(200);
+      expect(response1.body.length).toBe(1);
+      expect(response1.body[0]).toMatchObject({
+        ...taskData1,
+        userId: userId1,
+        tenantId: tenantId1
+      });
+
+      // Get tasks for user2 in tenant1 (should be empty)
+      nock(permissionServiceBaseUrl)
+        .get('/permissions/v2/check')
+        .query({
+          subjectId: userId2,
+          tenantId: tenantId1,
+          domain: 'TASK',
+          action: 'LIST'
+        })
+        .reply(200, { allowed: true });
+
+      const response2 = await request(app)
+        .get('/tasks')
+        .set('identity-user-id', userId2)
+        .set('identity-tenant-id', tenantId1);
+
+      expect(response2.status).toBe(200);
+      expect(response2.body).toEqual([]);
     });
   });
 });


### PR DESCRIPTION
This PR contains the following modifications:

- AI (gemini/gemini-2.5-flash-lite):
```
The company is moving to multi-tenant setup. This means we need to re-work how we evaluate permissions. Infra team has already implemented authentication and they add new identity-tenant-id header in the api-gateway.

The owners of permission-service have already implemented a new endpoint /permissions/v2/check that can accept tenantId along with existing subjectId.

So now all the other components need to be updated to the new version of permission-service. But all the feature teams are busy with building a new shiny AI integration and can not prioritize this upgrade.

Do not keep the old logic in permission service client.

```
 (Slicing enabled: No)

Generated by [Morph](https://codemorph.dev)