### PR TITLE
Morph: migrate to permission service

### DIFF
--- a/src/clients/permission-service.client.ts
+++ b/src/clients/permission-service.client.ts
@@ -33,14 +33,15 @@ export class PermissionServiceClient {
     console.log(`[PermissionServiceClient] Initialized with baseUrl: ${this.baseUrl}`);
   }
 
-  async hasPermission(subjectId: string, domain: Domain, action: Action): Promise<boolean> {
-    console.log(`[PermissionServiceClient] Checking permission for subjectId=${subjectId}, domain=${domain}, action=${action}`);
+  async hasPermission(subjectId: string, tenantId: string, domain: Domain, action: Action): Promise<boolean> {
+    console.log(`[PermissionServiceClient] Checking permission for subjectId=${subjectId}, tenantId=${tenantId}, domain=${domain}, action=${action}`);
     try {
       const response = await axios.get<PermissionResponse>(
-        `${this.baseUrl}/permissions/check`,
+        `${this.baseUrl}/permissions/v2/check`,
         {
           params: {
             subjectId,
+            tenantId,
             domain,
             action
           }

--- a/src/controllers/task.controller.ts
+++ b/src/controllers/task.controller.ts
@@ -12,13 +12,19 @@ export class TaskController {
     try {
       console.log('createTask called with body:', req.body);
       const userId = this.identityProvider.getUserId(req);
+      const tenantId = this.identityProvider.getTenantId(req); // Get tenantId from header
       if (!userId) {
         console.warn('User ID not provided for createTask');
         res.status(401).json({ error: 'User ID not provided' });
         return;
       }
+      if (!tenantId) {
+        console.warn('Tenant ID not provided for createTask');
+        res.status(401).json({ error: 'Tenant ID not provided' });
+        return;
+      }
 
-      const task = await this.taskService.createTask(userId, req.body);
+      const task = await this.taskService.createTask(userId, tenantId, req.body); // Pass tenantId
       console.log('Task created:', task);
       res.status(201).json(task);
     } catch (error) {
@@ -35,14 +41,20 @@ export class TaskController {
     try {
       console.log('getTasks called');
       const userId = this.identityProvider.getUserId(req);
+      const tenantId = this.identityProvider.getTenantId(req); // Get tenantId from header
       if (!userId) {
         console.warn('User ID not provided for getTasks');
         res.status(401).json({ error: 'User ID not provided' });
         return;
       }
+      if (!tenantId) {
+        console.warn('Tenant ID not provided for getTasks');
+        res.status(401).json({ error: 'Tenant ID not provided' });
+        return;
+      }
 
-      const tasks = await this.taskService.getTasks(userId);
-      console.log(`Tasks retrieved for user ${userId}:`, tasks);
+      const tasks = await this.taskService.getTasks(userId, tenantId); // Pass tenantId
+      console.log(`Tasks retrieved for user ${userId} in tenant ${tenantId}:`, tasks);
       res.status(200).json(tasks);
     } catch (error) {
       console.error('Error occurred in getTasks:', error);

--- a/src/middleware/identity.provider.ts
+++ b/src/middleware/identity.provider.ts
@@ -6,4 +6,10 @@ export class IdentityProvider {
     console.log(`[IdentityProvider] Extracted userId:`, userId);
     return userId || null;
   }
+
+  getTenantId(req: Request): string | null {
+    const tenantId = req.header('identity-tenant-id'); // Get tenantId from header
+    console.log(`[IdentityProvider] Extracted tenantId:`, tenantId);
+    return tenantId || null;
+  }
 }


### PR DESCRIPTION
This PR contains the following modifications:

- AI (gemini/gemini-2.5-flash-lite):
```
The company is moving to multi-tenant setup. This means we need to re-work how we evaluate permissions. Infra team has already implemented authentication and they add new identity-tenant-id header in the api-gateway.

The owners of permission-service have already implemented a new endpoint /permissions/v2/check that can accept tenantId along with existing subjectId.

So now all the other components need to be updated to the new version of permission-service. But all the feature teams are busy with building a new shiny AI integration and can not prioritize this upgrade.

Do not keep the old logic in permission service client.

```
 (Slicing enabled: No)

Generated by [Morph](https://codemorph.dev)