### PR TITLE
Morph: Permission service migration

### DIFF
--- a/src/clients/permission-service.client.ts
+++ b/src/clients/permission-service.client.ts
@@ -33,16 +33,17 @@ export class PermissionServiceClient {
     console.log(`[PermissionServiceClient] Initialized with baseUrl: ${this.baseUrl}`);
   }
 
-  async hasPermission(subjectId: string, domain: Domain, action: Action): Promise<boolean> {
-    console.log(`[PermissionServiceClient] Checking permission for subjectId=${subjectId}, domain=${domain}, action=${action}`);
+  async hasPermission(subjectId: string, domain: Domain, action: Action, tenantId?: string): Promise<boolean> {
+    console.log(`[PermissionServiceClient] Checking permission for subjectId=${subjectId}, domain=${domain}, action=${action}, tenantId=${tenantId}`);
     try {
       const response = await axios.get<PermissionResponse>(
-        `${this.baseUrl}/permissions/check`,
+        `${this.baseUrl}/v2/permissions/check`,
         {
           params: {
             subjectId,
             domain,
-            action
+            action,
+            tenantId
           }
         }
       );

--- a/src/controllers/task.controller.ts
+++ b/src/controllers/task.controller.ts
@@ -6,7 +6,9 @@ export class TaskController {
   constructor(
     private taskService: TaskService,
     private identityProvider: IdentityProvider
-  ) {}
+  ) {
+    req.tenantId = this.identityProvider.getTenantId(req);
+  }
 
   async createTask(req: Request, res: Response): Promise<void> {
     try {

--- a/src/middleware/identity.provider.ts
+++ b/src/middleware/identity.provider.ts
@@ -6,4 +6,10 @@ export class IdentityProvider {
     console.log(`[IdentityProvider] Extracted userId:`, userId);
     return userId || null;
   }
+
+  getTenantId(req: Request): string | null {
+    const tenantId = req.header('identity-tenant-id');
+    console.log(`[IdentityProvider] Extracted tenantId:`, tenantId);
+    return tenantId || null;
+  }
 }

--- a/src/services/task.service.ts
+++ b/src/services/task.service.ts
@@ -9,7 +9,7 @@ export class TaskService {
 
   async createTask(userId: string, createTaskRequest: CreateTaskRequest): Promise<Task> {
     console.log(`[TaskService] Checking CREATE permission for user: ${userId}`);
-    const hasPermission = await this.permissionServiceClient.hasPermission(userId, Domain.TASK, Action.CREATE);
+    const hasPermission = await this.permissionServiceClient.hasPermission(userId, Domain.TASK, Action.CREATE, req.tenantId);
     if (!hasPermission) {
       console.warn(`[TaskService] User ${userId} lacks permission to create task`);
       throw new Error('Insufficient permissions to create task');
@@ -28,7 +28,7 @@ export class TaskService {
 
   async getTasks(userId: string): Promise<Task[]> {
     console.log(`[TaskService] Checking LIST permission for user: ${userId}`);
-    const hasPermission = await this.permissionServiceClient.hasPermission(userId, Domain.TASK, Action.LIST);
+    const hasPermission = await this.permissionServiceClient.hasPermission(userId, Domain.TASK, Action.LIST, req.tenantId);
     if (!hasPermission) {
       console.warn(`[TaskService] User ${userId} lacks permission to list tasks`);
       throw new Error('Insufficient permissions to list tasks');


### PR DESCRIPTION
This PR contains the following modifications:

- AI (deepseek/deepseek-chat):
```
The company is moving to multi-tenant setup. This means we need to re-work how we evaluate permissions. Infra team has already implemented authentication and they add new identity-tenant-id header in the api-gateway.

The owners of permission-service have already implemented a new endpoint /v2/check that can accept tenantId along with existing subjectId.

So now all the other components need to be updated to the new version of permission-service. But all the feature teams are busy with building a new shiny AI integration and can not prioritize this upgrade.

The only hope is you.
```
 (Slicing enabled: No)

Generated by [Morph](https://codemorph.dev)